### PR TITLE
Update voucher redemption logic in PromotionService

### DIFF
--- a/src/promotion/promotion.service.ts
+++ b/src/promotion/promotion.service.ts
@@ -942,11 +942,13 @@ export class PromotionService {
 
     // Check voucher quantity limit if set
     if (promotion.voucherQuantity !== null && promotion.voucherQuantity !== undefined) {
-      // Count how many vouchers have been redeemed
+      // Count how many vouchers have been claimed (all non-CANCELLED redemptions)
       const redeemedCount = await this.prisma.voucherRedemption.count({
         where: {
           promotionId: dto.promotionId,
-          status: VoucherRedemptionStatus.REDEEMED,
+          status: {
+            not: VoucherRedemptionStatus.CANCELLED,
+          },
         },
       });
 
@@ -1281,11 +1283,13 @@ export class PromotionService {
       });
 
       if (promotion?.voucherQuantity !== null && promotion?.voucherQuantity !== undefined) {
-        // Count how many vouchers have been redeemed (excluding this one)
+        // Count how many vouchers have been claimed (all non-CANCELLED redemptions, excluding this one)
         const redeemedCount = await this.prisma.voucherRedemption.count({
           where: {
             promotionId: redemption.promotionId,
-            status: VoucherRedemptionStatus.REDEEMED,
+            status: {
+              not: VoucherRedemptionStatus.CANCELLED,
+            },
           },
         });
 


### PR DESCRIPTION
- Modified the logic to count claimed vouchers by excluding CANCELLED redemptions instead of just REDEEMED.
- Updated comments for clarity on the counting process in the context of voucher quantity limits.